### PR TITLE
Update testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,11 @@ jobs:
     - name: Set up conda environment
       run: |
         python -m pip install -e .
+        python -m pip install pytest-xdist
         conda list
 
     - name: Run Tests
-      run: pytest --cov=./ --cov-report=xml
+      run: pytest -n 4 --cov=./ --cov-report=xml
 
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v5.4.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         conda list
 
     - name: Run Tests
-      run: pytest -n auto --cov=./ --cov-report=xml
+      run: pytest -n auto -v --cov=./ --cov-report=xml
 
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v5.4.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         conda list
 
     - name: Run Tests
-      run: pytest -n 4 --cov=./ --cov-report=xml
+      run: pytest -n auto --cov=./ --cov-report=xml
 
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v5.4.3

--- a/.gitignore
+++ b/.gitignore
@@ -344,4 +344,7 @@ tags
 # Ignore code-workspaces
 *.code-workspace
 
+#
+.DS_Store
+
 # End of https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm

--- a/oceanspy/tests/test_oceandataset.py
+++ b/oceanspy/tests/test_oceandataset.py
@@ -424,5 +424,5 @@ def test_save_load(tmp_path, od, compute):
     open_oceandataset.from_netcdf(nc_path)
 
     zarr_path = str(tmp_path / "test.zarr")
-    od.to_zarr(path=zarr_path, compute=compute)
+    od.to_zarr(path=zarr_path, compute=compute, mode="w")
     open_oceandataset.from_zarr(zarr_path)


### PR DESCRIPTION
This PR:

- [x] Fixes to tests that fail locally (these always fail locally, but pass on github workflows) by forcing `mode='w'` when writing multiple times the same file (zarr). 
- [x] Improves speed of github workflows by installing [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/) when running ci testing.
- [x] This should close #451 
With these two changes, tests run in ~ 1.5 - 2 minutes locally (4 workers, and once the testing begins).



