### PR TITLE
pin numpy<2.4

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - distributed
 - bottleneck
 - netCDF4
-- numpy
+- numpy<2.4
 - xarray
 - xoak
 - cartopy


### PR DESCRIPTION
Newer versions of numpy are becoming stricter in how arrays or scalars are handled. By having pinned numpy buys some time to adapt how arrays/scalars are handled internally. For now, this is a quick patch. 

- [x] test pass locally