### PR TITLE
Transition to Kraken and ceph

### DIFF
--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -7,7 +7,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
       xarray_kwargs:
         engine: netcdf4
@@ -68,7 +67,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full_2007-09-01.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
@@ -89,7 +87,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/crop_2007-09-01.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/crop_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
@@ -389,7 +386,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
       xarray_kwargs:
         engine: netcdf4
@@ -441,7 +437,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full*.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
       xarray_kwargs:
         engine: netcdf4
@@ -522,7 +517,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full*.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
       xarray_kwargs:
         engine: netcdf4
@@ -546,7 +540,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/crop*.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/crop*.nc
       xarray_kwargs:
         engine: netcdf4

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -166,7 +166,7 @@ sources:
     description: Grid of IGPyearlong
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/vc1/IGPyearlong/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPyearlong/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -213,7 +213,7 @@ sources:
     description: Fields of IGPyearlong
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/vc1/IGPyearlong/day_*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPyearlong/day_*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -448,7 +448,7 @@ sources:
       engine: zarr
       concat_dim: T
       parallel: true
-      combine: nested
+        #combine: nested
     metadata:
       rename:
         T: time

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -383,15 +383,12 @@ sources:
   # EGshelfIIseas2km_ASR_full
   grd_EGshelfIIseas2km_ASR_full:
     description: Grid of EGshelfIIseas2km_ASR_full
-      #driver: netcdf
-    driver: zarr
+    driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/ldies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
-      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
     xarray_kwargs:
-        #engine: netcdf4
-      engine: zarr
+      engine: netcdf4
       drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
@@ -437,21 +434,18 @@ sources:
 
   fld_EGshelfIIseas2km_ASR_full:
     description: Fields of EGshelfIIseas2km_ASR_full
-      #driver: netcdf
-    driver: zarr
+    driver: netcdf
     model: MITGCM
     args:
-      #urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
-      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
     xarray_kwargs:
-        #engine: netcdf4
-      engine: zarr
-        #concat_dim: T
+      engine: netcdf4
+      concat_dim: T
       parallel: true
-        #combine: nested
+      combine: nested
     metadata:
-      #rename:
-        #T: time
+      rename:
+        T: time
       original_output: snapshot
 
   # ===========================

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -103,7 +103,7 @@ sources:
     description: Grid of IGPwinter
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/IGP/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGP/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -150,7 +150,7 @@ sources:
     description: Fields of IGPwinter
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/IGP/day*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGP/day*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T
@@ -230,7 +230,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ERAI/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -281,7 +281,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ERAI/6H*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/6H*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T
@@ -299,7 +299,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ERAI/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -350,7 +350,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ERAI/6H*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/6H*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T
@@ -368,7 +368,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ERAI/1D*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/1D*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T
@@ -689,7 +689,7 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: '/home/idies/workspace/OceanCirculation/ECCO_v4r4/ecco_v4r4'
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/ECCO_v4r4/ecco_v4r4
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
     metadata:
       swap_dims:
@@ -975,7 +975,7 @@ sources:
     model: MITGCM
     args:
       # urlpath: /sciserver/oceanography/exp_Arctic_Control/GRID/grid_glued_swapped.nc
-      urlpath: /home/idies/workspace/OceanCirculation/exp_Arctic_Control/GRID/grid_glued_swapped.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_Arctic_Control/GRID/grid_glued_swapped.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -103,7 +103,7 @@ sources:
     description: Grid of IGPwinter
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGP/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPwinter/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -150,7 +150,7 @@ sources:
     description: Fields of IGPwinter
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGP/day*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPwinter/day*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -7,7 +7,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -67,7 +68,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full_2007-09-01.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full_2007-09-01.nc
+      urlpath: /home/idies/workspace/cean_circulation_ceph/exp_ASR/full_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
     metadata:
@@ -87,7 +89,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/crop_2007-09-01.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/crop_2007-09-01.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/crop_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
     metadata:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -166,7 +166,7 @@ sources:
     description: Grid of IGPyearlong
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/ocean_circulation/data01_01/IGP/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/vc1/IGPyearlong/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -213,7 +213,7 @@ sources:
     description: Fields of IGPyearlong
     driver: netcdf
     args:
-      urlpath: /home/idies/workspace/ocean_circulation/data*_*/IGP/day_*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/vc1/IGPyearlong/day_*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -69,7 +69,7 @@ sources:
     model: MITGCM
     args:
       #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full_2007-09-01.nc
-      urlpath: /home/idies/workspace/cean_circulation_ceph/exp_ASR/full_2007-09-01.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
     metadata:
@@ -389,7 +389,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -440,7 +441,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full*.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T
@@ -458,7 +460,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -520,7 +522,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full*.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/full*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T
@@ -543,7 +546,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/crop*.nc
+      #urlpath: /home/idies/workspace/OceanCirculation/exp_ASR/crop*.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/crop*.nc
       xarray_kwargs:
         engine: netcdf4
         concat_dim: T

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -446,7 +446,7 @@ sources:
     xarray_kwargs:
         #engine: netcdf4
       engine: zarr
-      concat_dim: T
+        #concat_dim: T
       parallel: true
         #combine: nested
     metadata:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -974,7 +974,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      # urlpath: /sciserver/oceanography/exp_Arctic_Control/GRID/grid_glued_swapped.nc
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_Arctic_Control/GRID/grid_glued_swapped.nc
       xarray_kwargs:
         engine: netcdf4
@@ -1022,7 +1021,8 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: '/home/idies/workspace/poseidon/data10_02/arctic_control.zarr'
+      #urlpath: '/home/idies/workspace/poseidon/data10_02/arctic_control.zarr'
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_Arctic_Control/arctic_control.zarr
     xarray_kwargs:
       engine: zarr
     metadata:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -451,7 +451,7 @@ sources:
         #combine: nested
     metadata:
       rename:
-        T: time
+        #T: time
       original_output: snapshot
 
   # ===========================

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -389,10 +389,10 @@ sources:
     args:
       #urlpath: /home/ldies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
       urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr
-      xarray_kwargs:
+    xarray_kwargs:
         #engine: netcdf4
-        engine: zarr
-        drop_variables: ['RC', 'RF', 'RU', 'RL']
+      engine: zarr
+      drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
         fillna: true
@@ -443,12 +443,12 @@ sources:
     args:
       #urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
       urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr
-      xarray_kwargs:
+    xarray_kwargs:
         #engine: netcdf4
-        engine: zarr
-        concat_dim: T
-        parallel: true
-        combine: nested
+      engine: zarr
+      concat_dim: T
+      parallel: true
+      combine: nested
     metadata:
       rename:
         T: time

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -450,7 +450,7 @@ sources:
       parallel: true
         #combine: nested
     metadata:
-      rename:
+      #rename:
         #T: time
       original_output: snapshot
 

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -689,7 +689,7 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/ECCO_v4r4/ecco_v4r4
+      urlpath: /home/idies/workspace/poseidon_ceph/ecco_v4r4
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
     metadata:
       swap_dims:
@@ -786,7 +786,6 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      #urlpath: '/home/idies/workspace/poseidon/data03_02/daily_mean_ecco/ECCO-GRID.nc'
       urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/ECCO-GRID.nc
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
     metadata:
@@ -826,7 +825,6 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      #urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/snap*'
       urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/zarr/snap*
       drop_variables: ['XC', 'YC']
     xarray_kwargs:
@@ -845,7 +843,6 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      #urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/mean*'
       urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/zarr/mean*
       drop_variables: ['XC', 'YC', 'XG', 'YG', 'time_midp']
     xarray_kwargs:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -957,8 +957,7 @@ sources:
     driver: zarr
     model: NA
     args:
-      #urlpath: '/home/idies/workspace/poseidon/data12_01/ETOPO'
-      urlpath: '/home/idies/workspace/ocean_circulation_ceph/ETOPO'
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/ETOPO
     xarray_kwargs:
       engine: zarr
     metadata:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -846,7 +846,7 @@ sources:
     model: MITGCM
     args:
       #urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/mean*'
-      urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/zarr/mean*'
+      urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/zarr/mean*
       drop_variables: ['XC', 'YC', 'XG', 'YG', 'time_midp']
     xarray_kwargs:
       engine: zarr

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -383,12 +383,15 @@ sources:
   # EGshelfIIseas2km_ASR_full
   grd_EGshelfIIseas2km_ASR_full:
     description: Grid of EGshelfIIseas2km_ASR_full
-    driver: netcdf
+      #driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
+      #urlpath: /home/ldies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
+      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr
       xarray_kwargs:
-        engine: netcdf4
+        #engine: netcdf4
+        engine: zarr
         drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
@@ -434,12 +437,15 @@ sources:
 
   fld_EGshelfIIseas2km_ASR_full:
     description: Fields of EGshelfIIseas2km_ASR_full
-    driver: netcdf
+      #driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
+      #urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
+      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr
       xarray_kwargs:
-        engine: netcdf4
+        #engine: netcdf4
+        engine: zarr
         concat_dim: T
         parallel: true
         combine: nested

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -920,7 +920,6 @@ sources:
     driver: zarr
     model: HyCOM
     args:
-      #urlpath: /home/idies/workspace/poseidon/data10_01/HyCOM
       urlpath: /home/idies/workspace/ocean_circulation_ceph/HyCOM
     xarray_kwargs:
       engine: zarr
@@ -958,7 +957,8 @@ sources:
     driver: zarr
     model: NA
     args:
-      urlpath: '/home/idies/workspace/poseidon/data12_01/ETOPO'
+      #urlpath: '/home/idies/workspace/poseidon/data12_01/ETOPO'
+      urlpath: '/home/idies/workspace/ocean_circulation_ceph/ETOPO'
     xarray_kwargs:
       engine: zarr
     metadata:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -786,7 +786,8 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: '/home/idies/workspace/poseidon/data03_02/daily_mean_ecco/ECCO-GRID.nc'
+      #urlpath: '/home/idies/workspace/poseidon/data03_02/daily_mean_ecco/ECCO-GRID.nc'
+      urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/ECCO-GRID.nc
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
     metadata:
       swap_dims:
@@ -825,7 +826,8 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/snap*'
+      #urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/snap*'
+      urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/zarr/snap*
       drop_variables: ['XC', 'YC']
     xarray_kwargs:
       engine: zarr
@@ -843,7 +845,8 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/mean*'
+      #urlpath: '/home/idies/workspace/poseidon/data0*_02/daily_mean_ecco/zarr/mean*'
+      urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/zarr/mean*'
       drop_variables: ['XC', 'YC', 'XG', 'YG', 'time_midp']
     xarray_kwargs:
       engine: zarr
@@ -1021,7 +1024,6 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      #urlpath: '/home/idies/workspace/poseidon/data10_02/arctic_control.zarr'
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_Arctic_Control/arctic_control.zarr
     xarray_kwargs:
       engine: zarr

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -383,12 +383,12 @@ sources:
   # EGshelfIIseas2km_ASR_full
   grd_EGshelfIIseas2km_ASR_full:
     description: Grid of EGshelfIIseas2km_ASR_full
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
+      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr2
     xarray_kwargs:
-      engine: netcdf4
+      engine: zarr
       drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
@@ -434,18 +434,16 @@ sources:
 
   fld_EGshelfIIseas2km_ASR_full:
     description: Fields of EGshelfIIseas2km_ASR_full
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
+      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr2
     xarray_kwargs:
-      engine: netcdf4
+      engine: zarr
       concat_dim: T
       parallel: true
       combine: nested
     metadata:
-      rename:
-        T: time
       original_output: snapshot
 
   # ===========================

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -920,7 +920,8 @@ sources:
     driver: zarr
     model: HyCOM
     args:
-      urlpath: /home/idies/workspace/poseidon/data10_01/HyCOM
+      #urlpath: /home/idies/workspace/poseidon/data10_01/HyCOM
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/HyCOM
     xarray_kwargs:
       engine: zarr
     metadata:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -7,7 +7,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/get_started/grid.nc
       xarray_kwargs:
         engine: netcdf4
         drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -67,7 +67,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full_2007-09-01.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/get_started/full_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
     metadata:
@@ -87,7 +87,7 @@ sources:
     driver: netcdf
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/crop_2007-09-01.nc
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/get_started/crop_2007-09-01.nc
       xarray_kwargs:
         engine: netcdf4
     metadata:
@@ -101,12 +101,13 @@ sources:
   # IGP
   grd_IGPwinter:
     description: Grid of IGPwinter
-    driver: netcdf
+    model: MITGCM
+    driver: zarr
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPwinter/grid.nc
-      xarray_kwargs:
-        engine: netcdf4
-        drop_variables: ['RC', 'RF', 'RU', 'RL']
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPwinter_zarr
+    xarray_kwargs:
+      engine: zarr
+      drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
         coordsUVfromG: true
@@ -126,8 +127,8 @@ sources:
             Zl: -0.5
           time:
             time: -0.5
-      shift_averages:
-        averageList: ['UVELMASS', 'VVELMASS', 'WVELMASS', 'ADVr_TH', 'ADVx_TH', 'ADVy_TH', 'DFrI_TH', 'ADVr_SLT', 'ADVx_SLT', 'ADVy_SLT', 'DFrI_SLT', 'KPPg_TH', 'KPPg_SLT', 'oceSPtnd', 'oceQsw_AVG', 'TFLUX', 'SFLUX', 'oceFWflx_AVG']
+#      shift_averages:
+#        averageList: ['UVELMASS', 'VVELMASS', 'WVELMASS', 'ADVr_TH', 'ADVx_TH', 'ADVy_TH', 'DFrI_TH', 'ADVr_SLT', 'ADVx_SLT', 'ADVy_SLT', 'DFrI_SLT', 'KPPg_TH', 'KPPg_SLT', 'oceSPtnd', 'oceQsw_AVG', 'TFLUX', 'SFLUX', 'oceFWflx_AVG']
       parameters:
         rSphere: 6.371e+03
         eq_state: mdjwf
@@ -138,7 +139,7 @@ sources:
         c_p: 3.986e+03
         tempFrz0: 9.01e-02
         dTempFrz_dS: -5.75e-02
-      name: IGP
+      name: IGPwinter
       description: |
         High-resolution numerical simulation carried out in parallel to the observational
         component of the Iceland Greenland Seas Project (IGP).
@@ -148,28 +149,29 @@ sources:
 
   fld_IGPwinter:
     description: Fields of IGPwinter
-    driver: netcdf
+    model: MITGCM
+    driver: zarr
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPwinter/day*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPwinter_zarr
+    xarray_kwargs:
+      engine: zarr
+      concat_dim: T
+      parallel: true
+      combine: nested
     metadata:
-      rename:
-        T: time
+      original_output: snapshot
 
   # ===========================
   # IGPyearlong
   grd_IGPyearlong:
     description: Grid of IGPyearlong
-    driver: netcdf
+    driver: zarr
+    model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPyearlong/grid.nc
-      xarray_kwargs:
-        engine: netcdf4
-        drop_variables: ['RC', 'RF', 'RU', 'RL']
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPyearlong_zarr
+    xarray_kwargs:
+      engine: zarr
+      drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
         coordsUVfromG: true
@@ -189,8 +191,8 @@ sources:
             Zl: -0.5
           time:
             time: -0.5
-      shift_averages:
-        averageList: ['UVELMASS', 'VVELMASS', 'WVELMASS', 'ADVr_TH', 'ADVx_TH', 'ADVy_TH', 'DFrI_TH', 'ADVr_SLT', 'ADVx_SLT', 'ADVy_SLT', 'DFrI_SLT', 'KPPg_TH', 'KPPg_SLT', 'oceSPtnd', 'oceQsw_AVG', 'TFLUX', 'SFLUX', 'oceFWflx_AVG']
+#      shift_averages:
+#        averageList: ['UVELMASS', 'VVELMASS', 'WVELMASS', 'ADVr_TH', 'ADVx_TH', 'ADVy_TH', 'DFrI_TH', 'ADVr_SLT', 'ADVx_SLT', 'ADVy_SLT', 'DFrI_SLT', 'KPPg_TH', 'KPPg_SLT', 'oceSPtnd', 'oceQsw_AVG', 'TFLUX', 'SFLUX', 'oceFWflx_AVG']
       parameters:
         rSphere: 6.371e+03
         eq_state: mdjwf
@@ -211,29 +213,29 @@ sources:
 
   fld_IGPyearlong:
     description: Fields of IGPyearlong
-    driver: netcdf
+    model: MITGCM
+    driver: zarr
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPyearlong/day_*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/IGPyearlong_zarr
+    xarray_kwargs:
+      engine: zarr
+      concat_dim: T
+      parallel: true
+      combine: nested
     metadata:
-      rename:
-        T: time
+      original_output: snapshot
 
   # ===========================
   # EGshelfIIseas2km_ERAI_6H
   grd_EGshelfIIseas2km_ERAI_6H:
     description: Grid of EGshelfIIseas2km_ERAI_6H
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/grid.nc
-      xarray_kwargs:
-        engine: netcdf4
-        drop_variables: ['RC', 'RF', 'RU', 'RL']
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI_6H_zarr
+    xarray_kwargs:
+      engine: zarr
+      drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
         fillna: true
@@ -278,18 +280,16 @@ sources:
 
   fld_EGshelfIIseas2km_ERAI_6H:
     description: 6H-Fields of EGshelfIIseas2km_ERAI_6H
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/6H*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI_6H_zarr
+    xarray_kwargs:
+      engine: zarr
+      concat_dim: T
+      parallel: true
+      combine: nested
     metadata:
-      rename:
-        T: time
       original_output: snapshot
 
   # ===========================
@@ -386,7 +386,7 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr2
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR_zarr
     xarray_kwargs:
       engine: zarr
       drop_variables: ['RC', 'RF', 'RU', 'RL']
@@ -437,7 +437,7 @@ sources:
     driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/poseidon-staging/exp_ASR_zarr2
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR_zarr
     xarray_kwargs:
       engine: zarr
       concat_dim: T

--- a/sciserver_catalogs/catalog_xmitgcm.yaml
+++ b/sciserver_catalogs/catalog_xmitgcm.yaml
@@ -3,8 +3,8 @@
 KangerFjord:
   description: Kanger Fjord from SAMS
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromNeil
-    grid_dir: /home/idies/workspace/OceanCirculation/fromNeil
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromNeil
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromNeil
     delta_t: 5
     ref_date: '2007-08-21:30'
     grid_vars_to_coords: false
@@ -57,8 +57,8 @@ KangerFjord:
 EGshelfSJsec500m_3H_hydro:
   description: EGshelfSJsec500m_3H_hydro
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp1/all_result/3H/
-    grid_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp1/all_result
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp1/all_result/3H/
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp1/all_result
     delta_t: 6
     ref_date: '2003-06-01'
     grid_vars_to_coords: false
@@ -113,8 +113,8 @@ EGshelfSJsec500m_3H_hydro:
 fldEGshelfSJsec500m_6H_hydro:
   description: Fields of EGshelfSJsec500m_6H_hydro
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp1/all_result/3H/
-    grid_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp1/all_result
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp1/all_result/3H/
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp1/all_result
     delta_t: 6
     iters: range(0, 1321200+1, 3600)
     ref_date: '2003-06-01'
@@ -168,8 +168,8 @@ fldEGshelfSJsec500m_6H_hydro:
 exfEGshelfSJsec500m_6H_hydro:
   description: EXF fields of EGshelfSJsec500m_6H_hydro
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp1/all_result/6H/
-    grid_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp1/all_result
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp1/all_result/6H/
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp1/all_result
     delta_t: 6
     ref_date: '2003-06-01'
     grid_vars_to_coords: false
@@ -186,8 +186,8 @@ exfEGshelfSJsec500m_6H_hydro:
 EGshelfSJsec500m_3H_NONhydro:
   description: EGshelfSJsec500m_3H_NONhydro
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp6/all_result/3H/
-    grid_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp6/all_result
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp6/all_result/3H/
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp6/all_result
     delta_t: 6
     ref_date: '2003-06-01'
     grid_vars_to_coords: false
@@ -242,8 +242,8 @@ EGshelfSJsec500m_3H_NONhydro:
 fldEGshelfSJsec500m_6H_NONhydro:
   description: Fields of EGshelfSJsec500m_6H_NONhydro
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp6/all_result/3H/
-    grid_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp6/all_result
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp6/all_result/3H/
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp6/all_result
     delta_t: 6
     iters: range(0, 1321200+1, 3600)
     ref_date: '2003-06-01'
@@ -297,8 +297,8 @@ fldEGshelfSJsec500m_6H_NONhydro:
 exfEGshelfSJsec500m_6H_NONhydro:
   description: EXF fields of EGshelfSJsec500m_6H_NONhydro
   args:
-    data_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp6/all_result/6H/
-    grid_dir: /home/idies/workspace/OceanCirculation/fromMarcello/exp6/all_result
+    data_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp6/all_result/6H/
+    grid_dir: /home/idies/workspace/ocean_circulation_ceph/fromMarcello/exp6/all_result
     delta_t: 6
     ref_date: '2003-06-01'
     grid_vars_to_coords: false

--- a/sciserver_catalogs/datasets_list.yaml
+++ b/sciserver_catalogs/datasets_list.yaml
@@ -2,6 +2,7 @@ datasets:
   sciserver:
   - get_started
   - IGPwinter
+  - IGPyearlong
   - EGshelfIIseas2km_ASR_full
   - EGshelfIIseas2km_ASR_crop
   - EGshelfIIseas2km_ERAI_6H

--- a/sciserver_catalogs/datasets_list.yaml
+++ b/sciserver_catalogs/datasets_list.yaml
@@ -14,7 +14,7 @@ datasets:
   - Arctic_Control
   - KangerFjord
   - HYCOM
-  - LLC4320
+  # - LLC4320
   - ECCO
   - daily_ecco
   - ETOPO

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - geopy
 - xesmf>0.6.3
 - esmf
-- xgcm
+- xgcm=0.6.1
 - Ipython
 - tqdm
 - pytest
@@ -56,6 +56,7 @@ dependencies:
 - pre-commit
 - intake
 - intake-xarray
+- seaduck
 - pip:
   - black-nb
   - numbagg

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -57,6 +57,9 @@ dependencies:
 - intake
 - intake-xarray
 - seaduck
+- kerchunk
+- fsspec
+- fastparquet
 - pip:
   - black-nb
   - numbagg


### PR DESCRIPTION
* Update `sciserver_catalogs` to reflect new locations of OceanSpy datasets.
* `IGPwinter`, `IGPyearlong`, `exp_ASR`, and `exp_ERAI_6H` are now available in `zarr`.
* Deprecate `filedb` paths.
* `LLC4320` and `DYAMOND` datasets are now complete on SciServer (see [here](https://www.poseidon-ocean.net/blog/)). But not currently available from OceanSpy. Instead, open them directly following instructions [here (LLC4320)](https://www.poseidon-ocean.net/products/datasets/llc4320-dataset/) and [here (DYAMOND)](https://www.poseidon-ocean.net/access-process-for-the-dyamond-dataset-on-sciserver/).

To do: 

- [ ] Update `environment.yml`
- [ ] Create new `Oceanography` container image on SciServer
- [ ] Tweak `ListDatasets_*.ipynb` notebooks at [`Poseidon-share` repo](https://github.com/hainegroup/Poseidon-share/tree/main/Kraken)