### PR TITLE
Refactor catalog handling and add local catalog support

### DIFF
--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -34,9 +34,15 @@ import os as _os
 from pathlib import Path as _Path
 
 def _get_sciserver_catalog_dir():
-    """Return local catalog directory if OCEANSPY_CATALOG_DIR is set.
+    
+    """Return the SciServer catalog directory to use.
 
-    Falls back to the package's bundled sciserver_catalogs directory.
+    If the environment variable OCEANSPY_CATALOG_DIR is set, its value is
+    used as the catalog directory. Otherwise, the bundled sciserver_catalogs
+    directory in the OceanSpy source tree is used.
+
+    This is intended to support local development and testing of catalog YAML
+    changes without modifying the package code.
     """
     env_dir = _os.environ.get("OCEANSPY_CATALOG_DIR")
     if env_dir:
@@ -484,11 +490,11 @@ def _find_entries(name, catalog_url):
             url = cat_dir / "catalog_xarray.yaml"
 
         # If local file exists, use it; otherwise fall back to GitHub
-        if not url.exists():
-            url = (
-                "https://raw.githubusercontent.com/hainegroup/oceanspy/"
-                "main/sciserver_catalogs/catalog_xarray.yaml"
-            )
+            if not url.exists():
+                url = (
+                    "https://raw.githubusercontent.com/hainegroup/oceanspy/"
+                    "main/sciserver_catalogs/catalog_xarray.yaml"
+                )
         else:
             url = catalog_url
 
@@ -512,7 +518,7 @@ def _find_entries(name, catalog_url):
         else:
             url = catalog_url  # provided by user
 
-    cat = _intake.open_catalog(str(url))
+        cat = _intake.open_catalog(str(url))
     
         # Is it an url?
         try:

--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -29,6 +29,21 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
+# To allow local catalog reading
+import os as _os
+from pathlib import Path as _Path
+
+def _get_sciserver_catalog_dir():
+    """Return local catalog directory if OCEANSPY_CATALOG_DIR is set.
+
+    Falls back to the package's bundled sciserver_catalogs directory.
+    """
+    env_dir = _os.environ.get("OCEANSPY_CATALOG_DIR")
+    if env_dir:
+        return _Path(env_dir).expanduser().resolve()
+
+    # Default: bundled catalogs in the source tree / installed package
+    return _Path(__file__).resolve().parent.parent / "sciserver_catalogs"
 
 def from_netcdf(path, **kwargs):
     """
@@ -434,14 +449,25 @@ def _find_entries(name, catalog_url):
     -------
     cat, entries, url, intake_switch
     """
+    
     # Check parameters
     if catalog_url is None:  # pragma: no cover
-        url = (
-            "https://raw.githubusercontent.com/hainegroup/oceanspy/"
-            "main/sciserver_catalogs/datasets_list.yaml"
-        )
-        f = _urllib.request.urlopen(url)
-        SCISERVER_DATASETS = _yaml.safe_load(f)["datasets"]["sciserver"]
+        cat_dir = _get_sciserver_catalog_dir()
+
+        # datasets_list.yaml
+        datasets_list_path = cat_dir / "datasets_list.yaml"
+        if datasets_list_path.exists():
+            with open(datasets_list_path, "r") as f:
+                SCISERVER_DATASETS = _yaml.safe_load(f)["datasets"]["sciserver"]
+        else:
+            # Fallback to remote datasets list if local file is missing
+            url = (
+                "https://raw.githubusercontent.com/hainegroup/oceanspy/"
+                "main/sciserver_catalogs/datasets_list.yaml"
+            )
+            f = _urllib.request.urlopen(url)
+            SCISERVER_DATASETS = _yaml.safe_load(f)["datasets"]["sciserver"]
+
         if name not in SCISERVER_DATASETS:
             raise ValueError(
                 "[{}] is not available on SciServer."
@@ -454,26 +480,40 @@ def _find_entries(name, catalog_url):
     # Read catalog
     try:
         if catalog_url is None:
+            cat_dir = _get_sciserver_catalog_dir()
+            url = cat_dir / "catalog_xarray.yaml"
+
+        # If local file exists, use it; otherwise fall back to GitHub
+        if not url.exists():
             url = (
                 "https://raw.githubusercontent.com/hainegroup/oceanspy/"
                 "main/sciserver_catalogs/catalog_xarray.yaml"
             )
         else:
             url = catalog_url
-        cat = _intake.open_catalog(url)
+
+        cat = _intake.open_catalog(str(url))
         entries = [entry for entry in list(cat) if name in entry]
         if len(entries) == 0:
             raise ValidationError("", "")
         intake_switch = True
+
     except ValidationError:
         if catalog_url is None:
-            url = (
-                "https://raw.githubusercontent.com/hainegroup/oceanspy/"
-                "main/sciserver_catalogs/catalog_xmitgcm.yaml"
-            )
+            cat_dir = _get_sciserver_catalog_dir()
+            url = cat_dir / "catalog_xmitgcm.yaml"
+
+            # If local file exists, use it; otherwise fall back to GitHub
+            if not url.exists():
+                url = (
+                    "https://raw.githubusercontent.com/hainegroup/oceanspy/"
+                    "main/sciserver_catalogs/catalog_xmitgcm.yaml"
+                )
         else:
             url = catalog_url  # provided by user
 
+    cat = _intake.open_catalog(str(url))
+    
         # Is it an url?
         try:
             f = _urllib.request.urlopen(url)

--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -51,6 +51,18 @@ def _get_sciserver_catalog_dir():
     # Default: bundled catalogs in the source tree / installed package
     return _Path(__file__).resolve().parent.parent / "sciserver_catalogs"
 
+def _get_catalog_path(filename):
+    """
+    Return a local catalog path from OCEANSPY_CATALOG_DIR.
+
+    Raises FileNotFoundError if the file does not exist.
+    """
+    cat_dir = _get_sciserver_catalog_dir()
+    path = cat_dir / filename
+    if not path.exists():
+        raise FileNotFoundError(f"Could not find local catalog: {path}")
+    return path
+
 def from_netcdf(path, **kwargs):
     """
     Load an OceanDataset from a netcdf file.
@@ -484,52 +496,44 @@ def _find_entries(name, catalog_url):
         _check_instance({"catalog_url": catalog_url}, "str")
 
     # Read catalog
+    if catalog_url is None:
+        xarray_url = _get_catalog_path("catalog_xarray.yaml")
+        xmitgcm_url = _get_catalog_path("catalog_xmitgcm.yaml")
+    else:
+        xarray_url = catalog_url
+        xmitgcm_url = catalog_url
+
+    # Try intake/xarray catalog first
     try:
-        if catalog_url is None:
-            cat_dir = _get_sciserver_catalog_dir()
-            url = cat_dir / "catalog_xarray.yaml"
-
-        # If local file exists, use it; otherwise fall back to GitHub
-            if not url.exists():
-                url = (
-                    "https://raw.githubusercontent.com/hainegroup/oceanspy/"
-                    "main/sciserver_catalogs/catalog_xarray.yaml"
-                )
-        else:
-            url = catalog_url
-
-        cat = _intake.open_catalog(str(url))
+        url = xarray_url
+        cat = _intake.open_catalog(str(xarray_url))
         entries = [entry for entry in list(cat) if name in entry]
         if len(entries) == 0:
             raise ValidationError("", "")
         intake_switch = True
 
     except ValidationError:
-        if catalog_url is None:
-            cat_dir = _get_sciserver_catalog_dir()
-            url = cat_dir / "catalog_xmitgcm.yaml"
-
-            # If local file exists, use it; otherwise fall back to GitHub
-            if not url.exists():
-                url = (
-                    "https://raw.githubusercontent.com/hainegroup/oceanspy/"
-                    "main/sciserver_catalogs/catalog_xmitgcm.yaml"
-                )
-        else:
-            url = catalog_url  # provided by user
-
-        cat = _intake.open_catalog(str(url))
-    
-        # Is it an url?
-        try:
-            f = _urllib.request.urlopen(url)
-            cat = _yaml.safe_load(f)
-        except ValueError:
-            with open(url) as f:
+        # Fallback to xmitgcm-style YAML
+        url = xmitgcm_url
+        if isinstance(xmitgcm_url, _Path):
+            with open(xmitgcm_url, "r") as f:
                 cat = _yaml.safe_load(f)
+        else:
+            try:
+                with _urllib.request.urlopen(xmitgcm_url) as f:
+                    cat = _yaml.safe_load(f)
+            except Exception:
+                with open(xmitgcm_url, "r") as f:
+                    cat = _yaml.safe_load(f)
+
         entries = [entry for entry in list(cat) if name in entry]
         intake_switch = False
-
+        
+    # print("DEBUG: xarray_url =", xarray_url)
+    # print("DEBUG: xmitgcm_url =", xmitgcm_url)
+    # print("DEBUG: intake_switch =", intake_switch)
+    # print("DEBUG: entries =", entries)
+    
     # Error if not available
     if len(entries) == 0:
         raise ValueError("[{}] is not in the catalog.".format(name))

--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -33,8 +33,8 @@ except ImportError:  # pragma: no cover
 import os as _os
 from pathlib import Path as _Path
 
+
 def _get_sciserver_catalog_dir():
-    
     """Return the SciServer catalog directory to use.
 
     If the environment variable OCEANSPY_CATALOG_DIR is set, its value is
@@ -51,6 +51,7 @@ def _get_sciserver_catalog_dir():
     # Default: bundled catalogs in the source tree / installed package
     return _Path(__file__).resolve().parent.parent / "sciserver_catalogs"
 
+
 def _get_catalog_path(filename):
     """
     Return a local catalog path from OCEANSPY_CATALOG_DIR.
@@ -62,6 +63,7 @@ def _get_catalog_path(filename):
     if not path.exists():
         raise FileNotFoundError(f"Could not find local catalog: {path}")
     return path
+
 
 def from_netcdf(path, **kwargs):
     """
@@ -467,7 +469,7 @@ def _find_entries(name, catalog_url):
     -------
     cat, entries, url, intake_switch
     """
-    
+
     # Check parameters
     if catalog_url is None:  # pragma: no cover
         cat_dir = _get_sciserver_catalog_dir()
@@ -528,12 +530,12 @@ def _find_entries(name, catalog_url):
 
         entries = [entry for entry in list(cat) if name in entry]
         intake_switch = False
-        
+
     # print("DEBUG: xarray_url =", xarray_url)
     # print("DEBUG: xmitgcm_url =", xmitgcm_url)
     # print("DEBUG: intake_switch =", intake_switch)
     # print("DEBUG: entries =", entries)
-    
+
     # Error if not available
     if len(entries) == 0:
         raise ValueError("[{}] is not in the catalog.".format(name))

--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -531,11 +531,6 @@ def _find_entries(name, catalog_url):
         entries = [entry for entry in list(cat) if name in entry]
         intake_switch = False
 
-    # print("DEBUG: xarray_url =", xarray_url)
-    # print("DEBUG: xmitgcm_url =", xmitgcm_url)
-    # print("DEBUG: intake_switch =", intake_switch)
-    # print("DEBUG: entries =", entries)
-
     # Error if not available
     if len(entries) == 0:
         raise ValueError("[{}] is not in the catalog.".format(name))

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -781,13 +781,14 @@ sources:
 # ECCOv4r4 data
   daily_ecco_grid:
     description: ECCO version 4 release 4 grid
-    driver: netcdf4
+    driver: netcdf
     model: MITGCM
     args:
       urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/ECCO-GRID.nc
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
-    # xarray_kwargs:
-    #   engine: netcdf4
+      engine: netcdf4
+    xarray_kwargs:
+      engine: netcdf4
     metadata:
       swap_dims:
         k: Z

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -781,13 +781,13 @@ sources:
 # ECCOv4r4 data
   daily_ecco_grid:
     description: ECCO version 4 release 4 grid
-    driver: netcdf
+    driver: netcdf4
     model: MITGCM
     args:
       urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/ECCO-GRID.nc
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
-    xarray_kwargs:
-      engine: netcdf4
+    # xarray_kwargs:
+    #   engine: netcdf4
     metadata:
       swap_dims:
         k: Z

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -786,6 +786,8 @@ sources:
     args:
       urlpath: /home/idies/workspace/poseidon_ceph/daily_mean_ecco/ECCO-GRID.nc
       #drop_variables: ['k_u', 'k_p1', 'k_l', 'k']
+    xarray_kwargs:
+      engine: netcdf4
     metadata:
       swap_dims:
         k: Z

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -296,12 +296,12 @@ sources:
   # EGshelfIIseas2km_ERAI_1D
   grd_EGshelfIIseas2km_ERAI_1D:
     description: Grid of EGshelfIIseas2km_ERAI_1D
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/grid.nc
-      xarray_kwargs:
-        engine: netcdf4
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI_1D_zarr
+    xarray_kwargs:
+        engine: zarr
         drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
@@ -346,38 +346,20 @@ sources:
       projection: Mercator
 
   fld_EGshelfIIseas2km_ERAI_1D:
-    description: 6H-Fields of EGshelfIIseas2km_ERAI_1D
-    driver: netcdf
+    description: Daily-Fields of EGshelfIIseas2km_ERAI_1D
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/6H*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI_1D_zarr
+    xarray_kwargs:
+      engine: zarr
+      concat_dim: T
+      parallel: false
+      combine: nested
     metadata:
-      rename:
-        T: time
       original_output: snapshot
       isel:
         time: slice(None, None, 4)
-
-  dailyEGshelfIIseas2km_ERAI_1D:
-    description: Daily-Fields of EGshelfIIseas2km_ERAI_1D
-    driver: netcdf
-    model: MITGCM
-    args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI/1D*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
-    metadata:
-      rename:
-        T: time
-      original_output: snapshot
 
   # ===========================
   # EGshelfIIseas2km_ASR_full
@@ -445,18 +427,18 @@ sources:
       combine: nested
     metadata:
       original_output: snapshot
-
+      
   # ===========================
   # EGshelfIIseas2km_ASR_crop
   grd_EGshelfIIseas2km_ASR_crop:
     description: Grid of EGshelfIIseas2km_ASR_crop
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/grid.nc
-      xarray_kwargs:
-        engine: netcdf4
-        drop_variables: ['RC', 'RF', 'RU', 'RL']
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR_zarr
+    xarray_kwargs:
+      engine: zarr
+      drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
         fillna: true
@@ -475,8 +457,6 @@ sources:
             Zp1: 0.5
             Zu: 0.5
             Zl: -0.5
-          time:
-            time: -0.5
       shift_averages:
         averageList:
       isel:
@@ -512,15 +492,12 @@ sources:
 
   fld_EGshelfIIseas2km_ASR_crop:
     description: Full-Fields of EGshelfIIseas2km_ASR_crop
-    driver: netcdf
+    driver: zarr
     model: MITGCM
     args:
-      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/full*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
+      urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR_zarr
+    xarray_kwargs:
+      engine: zarr
     metadata:
       isel:
         Z: slice(None, 55)
@@ -529,156 +506,22 @@ sources:
         Xp1: slice(529, 737)
         Y: slice(582, 736)
         Yp1: slice(582, 737)
-      rename:
-        T: time
       original_output: snapshot
-
+      
   avg_EGshelfIIseas2km_ASR_crop:
     description: Cropped-Fields of EGshelfIIseas2km_ASR_crop
     driver: netcdf
     model: MITGCM
     args:
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ASR/crop*.nc
-      xarray_kwargs:
-        engine: netcdf4
-        concat_dim: T
-        parallel: true
-        combine: nested
+      engine: h5netcdf
+      concat_dim: T
+      parallel: true
+      combine: nested
     metadata:
       rename:
         T: time
       original_output: average
-
-  LLC4320_flds:
-    description: 10 day sample of hourly data from the LLC4320 simulation
-    driver: zarr
-    args:
-      urlpath: '/home/idies/workspace/poseidon/data*/llc4320_tests/10dayhourly/velocities'
-      engine: zarr
-      parallel: true
-    metadata:
-      swap_dims:
-        k: Z
-        k_p1: Zp1
-        k_u: Zu
-        k_l: Zl
-      rename:
-        Theta: Temp
-        Salt: S
-        i: X
-        i_g: Xp1
-        j: Y
-        j_g: Yp1
-      parameters:
-        rSphere: 6.371e+03
-        eq_state: jmd95
-        rho0: 1027
-        g: 9.81
-        eps_nh: 0
-        omega: 7.292123516990373e-05
-        c_p: 3.986e+03
-        tempFrz0: 9.01e-02
-        dTempFrz_dS: -5.75e-02
-      name: LLC4320
-      description: |
-        10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
-      projection:
-      original_output: snapshot
-
-
-  LLC4320_grid:
-    description: 10 day sample of hourly data from the LLC4320 simulation
-    driver: zarr
-    args:
-      urlpath: '/home/idies/workspace/poseidon/data01_01/llc4320_grid/'
-      engine: zarr
-    metadata:
-      swap_dims:
-        k: Z
-        k_p1: Zp1
-        k_u: Zu
-        k_l: Zl
-      rename:
-        i: X
-        i_g: Xp1
-        j: Y
-        j_g: Yp1
-        hFacC: HFacC
-        hFacW: HFacW
-        hFacS: HFacS
-      grid_coords:
-        add_midp: true
-        grid_coords:
-          Y:
-            Y:
-            Yp1: -0.5
-          X:
-            X:
-            Xp1: -0.5
-          Z:
-            Z:
-            Zp1: 0.5
-            Zu: 0.5
-            Zl: -0.5
-          time:
-            time: -0.5
-      face_connections: # topology
-        face_connections:
-          face:
-            0:
-              X: tuple(((12, 'Y', False), (3, 'X', False)))
-              Y: tuple((None,(1,'Y',False)))
-            1:
-              X: tuple(((11,'Y',False),(4,'X',False)))
-              Y: tuple(((0,'Y',False),(2,'Y',False)))
-            2:
-              X: tuple(((10,'Y',False),(5, 'X', False)))
-              Y: tuple(((1, 'Y', False), (6, 'X', False)))
-            3:
-              X: tuple(((0, 'X', False), (9, 'Y', False)))
-              Y: tuple((None, (4, 'Y', False)))
-            4:
-              X: tuple(((1, 'X', False), (8, 'Y', False)))
-              Y: tuple(((3, 'Y', False), (5, 'Y', False)))
-            5:
-              X: tuple(((2, 'X', False), (7, 'Y', False)))
-              Y: tuple(((4, 'Y', False), (6, 'Y', False)))
-            6:
-              X: tuple(((2, 'Y', False), (7, 'X', False)))
-              Y: tuple(((5, 'Y', False), (10, 'X', False)))
-            7:
-              X: tuple(((6, 'X', False), (8, 'X', False)))
-              Y: tuple(((5, 'X', False), (10, 'Y', False)))
-            8:
-              X: tuple(((7, 'X', False), (9, 'X', False)))
-              Y: tuple(((4, 'X', False), (11, 'Y', False)))
-            9:
-              X: tuple(((8, 'X', False), None))
-              Y: tuple(((3, 'X', False), (12, 'Y', False)))
-            10:
-              X: tuple(((6, 'Y', False), (11, 'X', False)))
-              Y: tuple(((7, 'Y', False), (2, 'X', False)))
-            11:
-              X: tuple(((10, 'X', False), (12, 'X', False)))
-              Y: tuple(((8, 'Y', False), (1, 'X', False)))
-            12:
-              X: tuple(((11, 'X', False), None))
-              Y: tuple(((9, 'Y', False), (0, 'X', False)))
-      parameters:
-        rSphere: 6.371e+03
-        eq_state: jmd95
-        rho0: 1027
-        g: 9.81
-        eps_nh: 0
-        omega: 7.292123516990373e-05
-        c_p: 3.986e+03
-        tempFrz0: 9.01e-02
-        dTempFrz_dS: -5.75e-02
-      name: LLC4320
-      description: |
-        10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
-      projection:
-      original_output: snapshot
 
 # ======================================================================
 # ECCOv4r4 data
@@ -1010,8 +853,6 @@ sources:
         c_p: 3.986e+03
         tempFrz0: 9.01e-02
         dTempFrz_dS: -5.75e-02
-        grid_type: 'spherical'
-      # grid_type: spherical
       name: Arctic_Control
       description: |
         Curvilinear grid test. Setup by Dr. Renske Gelderloos.
@@ -1028,6 +869,5 @@ sources:
     metadata:
       rename:
         T: time
-        # THETA: Temp
       manipulate_coords:
         coordsUVfromG: true

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -301,8 +301,8 @@ sources:
     args:
       urlpath: /home/idies/workspace/ocean_circulation_ceph/exp_ERAI_1D_zarr
     xarray_kwargs:
-        engine: zarr
-        drop_variables: ['RC', 'RF', 'RU', 'RL']
+      engine: zarr
+      drop_variables: ['RC', 'RF', 'RU', 'RL']
     metadata:
       manipulate_coords:
         fillna: true
@@ -427,7 +427,7 @@ sources:
       combine: nested
     metadata:
       original_output: snapshot
-      
+
   # ===========================
   # EGshelfIIseas2km_ASR_crop
   grd_EGshelfIIseas2km_ASR_crop:
@@ -507,7 +507,7 @@ sources:
         Y: slice(582, 736)
         Yp1: slice(582, 737)
       original_output: snapshot
-      
+
   avg_EGshelfIIseas2km_ASR_crop:
     description: Cropped-Fields of EGshelfIIseas2km_ASR_crop
     driver: netcdf


### PR DESCRIPTION
To support SciServer ceph storage and easier development and debugging. 

A new environment variable is defined in `open_oceandataset.py`--`OCEANSPY_CATALOG_DIR`--which determines whether local catalog `.yaml` files are read for dataset loading, or the default repo `.yaml` files. This is to facilitate local development and testing.

Also, changes are made to `catalog_xarray.yaml` and `catalog_xmitgcm.yaml` to work with SciServer ceph storage.