### PR TITLE
drop python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
     needs: prime-data
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
     steps:
     - uses: actions/checkout@v7
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: ospy_docs
 channels:
 - conda-forge
 dependencies:
-- python=3.10
+- python=3.12
 - pandoc
 - sphinx
 - sphinx_rtd_theme


### PR DESCRIPTION
This PR
- [x] drops python 3.11 from its github workflows. 
- [x] sets as python>=3.12 as its requirements.


NOTE: These changes will only apply the a new release (and we are months away from that), or if oceanspy is installed from source (extremely rare). This will allow us to work on oceanspy to modernize it, and to shift the focus for py>=3.12. 